### PR TITLE
Wrap WgetDownload in LimitConcurrent

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -74,6 +74,11 @@ USER_AGENT = 'ArchiveTeam'
 TRACKER_ID = 'vidme2'
 TRACKER_HOST = 'tracker.archiveteam.org'
 
+###########################################################################
+# Settings configurable via --context-value
+#
+if "WGET_THREADS" not in locals():
+    WGET_THREADS = "4"
 
 ###########################################################################
 # This section defines project-specific tasks.
@@ -306,7 +311,7 @@ pipeline = Pipeline(
     GetItemFromTracker("http://%s/%s" % (TRACKER_HOST, TRACKER_ID), downloader,
         VERSION),
     PrepareDirectories(warc_prefix="vidme"),
-	LimitConcurrent(NumberConfigValue(min=1, max=20, default="4",
+	LimitConcurrent(NumberConfigValue(min=1, max=20, default=WGET_THREADS,
         name="shared:wget_threads", title="Wget threads",
         description="The maximum number of concurrent downloads."),
 		WgetDownload(

--- a/pipeline.py
+++ b/pipeline.py
@@ -306,16 +306,20 @@ pipeline = Pipeline(
     GetItemFromTracker("http://%s/%s" % (TRACKER_HOST, TRACKER_ID), downloader,
         VERSION),
     PrepareDirectories(warc_prefix="vidme"),
-    WgetDownload(
-        WgetArgs(),
-        max_tries=2,
-        accept_on_exit_code=[0, 4, 8],
-        env={
-            "item_dir": ItemValue("item_dir"),
-            "item_value": ItemValue("item_value"),
-            "item_type": ItemValue("item_type"),
-            "warc_file_base": ItemValue("warc_file_base"),
-        }
+	LimitConcurrent(NumberConfigValue(min=1, max=20, default="4",
+        name="shared:wget_threads", title="Wget threads",
+        description="The maximum number of concurrent downloads."),
+		WgetDownload(
+		    WgetArgs(),
+		    max_tries=2,
+		    accept_on_exit_code=[0, 4, 8],
+		    env={
+		        "item_dir": ItemValue("item_dir"),
+		        "item_value": ItemValue("item_value"),
+		        "item_type": ItemValue("item_type"),
+		        "warc_file_base": ItemValue("warc_file_base"),
+		    }
+		),
     ),
     DeduplicateWarc(),
     PrepareStatsForTracker(


### PR DESCRIPTION
The default limit is 4. From the IRC discussions, 4 appears to be the recommended concurrency level for this project. It can be changed with --context-value WGET_THREADS=N when running run-pipeline.

With this change, you can run run-pipeline with --concurrent 20 and still only have up to 4 downloads going at the same time. The reason is to allow more finished jobs to wait in line for RsyncUpload to improve bandwidth utilization. This, of course, increases peak disk usage, so users with low disk space should still not raise the concurrent level.

Suppose we are running with --concurrent 4. Sometimes we can have a big job in RsyncUpload and 3 0MB jobs waiting for RsyncUpload. The upload bandwidth is saturated and the download bandwidth sits idle. Then, when the big job finishes uploading, all the 0MB jobs finish uploading instantly. Now all 4 threads are downloading and the upload bandwidth sits idle. If we allow more jobs to line up for RsyncUpload by wrapping WgetDownload in LimitConcurrent and running with --concurrent 20, there is a higher chance that one of the jobs waiting for upload will not be 0MB, and the upload bandwidth will continue to be utilized when the big job finishes uploading.